### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 17)
 add_subdirectory(modules)
 include_directories(modules)
 
-juce_set_aax_sdk_path(C:/SDKs/AAX_SDK/)
+#juce_set_aax_sdk_path(C:/SDKs/AAX_SDK/)
 
 set(JUCE_FORMATS AU VST3)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ juce_add_plugin(Chameleon
     PLUGIN_CODE Chm3 
     FORMATS ${JUCE_FORMATS}
     ProductName "Chameleon"
-    LV2_URI https://github.com/GuitarML/Chameleon
+    LV2URI https://github.com/GuitarML/Chameleon
     LV2_SHARED_LIBRARY_NAME Chameleon
     ICON_BIG resources/logo.png
 


### PR DESCRIPTION
- with aax set like that, the Linux build fails (it's changed like than in other GuitarML projects).
- the LV2URI wasn't set properly (it's also fixed this way in other GuitarML project).